### PR TITLE
Support AWS credentials on configuration file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,12 @@ Run tests:
 $ rake test
 ```
 
+Or, If you do not want to use IAM roll or ENV(this is just like writing to configuration file) :
+
+```
+$ rake aws_key_id=YOUR_ACCESS_KEY aws_sec_key=YOUR_SECRET_KEY region=us-east-1 test
+```
+
 ## TODO
 
 * out_cloudwatch_logs

--- a/lib/fluent/plugin/in_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/in_cloudwatch_logs.rb
@@ -2,6 +2,9 @@ module Fluent
   class CloudwatchLogsInput < Input
     Plugin.register_input('cloudwatch_logs', self)
 
+    config_param :aws_key_id, :string, :default => nil
+    config_param :aws_sec_key, :string, :default => nil
+    config_param :region, :string, :default => nil
     config_param :tag, :string
     config_param :log_group_name, :string
     config_param :log_stream_name, :string
@@ -12,10 +15,14 @@ module Fluent
       super
 
       require 'aws-sdk-core'
-      @logs = Aws::CloudWatchLogs.new
     end
 
     def start
+      options = {}
+      options[:credentials] = Aws::Credentials.new(@aws_key_id, @aws_sec_key) if @aws_key_id && @aws_sec_key
+      options[:region] = @region if @region
+      @logs = Aws::CloudWatchLogs.new(options)
+
       @finished = false
       @thread = Thread.new(&method(:run))
     end

--- a/lib/fluent/plugin/out_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/out_cloudwatch_logs.rb
@@ -2,6 +2,9 @@ module Fluent
   class CloudwatchLogsOutput < BufferedOutput
     Plugin.register_output('cloudwatch_logs', self)
 
+    config_param :aws_key_id, :string, :default => nil
+    config_param :aws_sec_key, :string, :default => nil
+    config_param :region, :string, :default => nil
     config_param :log_group_name, :string
     config_param :log_stream_name, :string
     config_param :sequence_token_file, :string
@@ -15,11 +18,15 @@ module Fluent
       super
 
       require 'aws-sdk-core'
-      @logs = Aws::CloudWatchLogs.new
     end
 
-    def configure(conf)
+    def start
       super
+
+      options = {}
+      options[:credentials] = Aws::Credentials.new(@aws_key_id, @aws_sec_key) if @aws_key_id && @aws_sec_key
+      options[:region] = @region if @region
+      @logs = Aws::CloudWatchLogs.new(options)
 
       create_stream if @auto_create_stream
     end
@@ -78,4 +85,3 @@ module Fluent
     end
   end
 end
-

--- a/test/plugin/test_in_cloudwatch_logs.rb
+++ b/test/plugin/test_in_cloudwatch_logs.rb
@@ -16,12 +16,18 @@ class CloudwatchLogsInputTest < Test::Unit::TestCase
   def test_configure
     d = create_driver(<<-EOC)
       type cloudwatch_logs
+      aws_key_id test_id
+      aws_sec_key test_key
+      region us-east-1
       tag test
       log_group_name group
       log_stream_name stream
       state_file /tmp/state
     EOC
 
+    assert_equal('test_id', d.instance.aws_key_id)
+    assert_equal('test_key', d.instance.aws_sec_key)
+    assert_equal('us-east-1', d.instance.region)
     assert_equal('test', d.instance.tag)
     assert_equal('group', d.instance.log_group_name)
     assert_equal('stream', d.instance.log_stream_name)
@@ -43,7 +49,7 @@ class CloudwatchLogsInputTest < Test::Unit::TestCase
     d.run do
       sleep 5
     end
-    
+
     emits = d.emits
     assert_equal(2, emits.size)
     assert_equal(['test', (time_ms / 1000).floor, {'cloudwatch' => 'logs1'}], emits[0])
@@ -58,6 +64,9 @@ class CloudwatchLogsInputTest < Test::Unit::TestCase
       log_group_name #{log_group_name}
       log_stream_name #{log_stream_name}
       state_file /tmp/state
+      #{aws_key_id}
+      #{aws_sec_key}
+      #{region}
     EOC
   end
 
@@ -65,4 +74,3 @@ class CloudwatchLogsInputTest < Test::Unit::TestCase
     Fluent::Test::InputTestDriver.new(Fluent::CloudwatchLogsInput).configure(conf)
   end
 end
-

--- a/test/plugin/test_out_cloudwatch_logs.rb
+++ b/test/plugin/test_out_cloudwatch_logs.rb
@@ -8,24 +8,29 @@ class CloudwatchLogsOutputTest < Test::Unit::TestCase
     Fluent::Test.setup
     require 'fluent/plugin/out_cloudwatch_logs'
 
-    @logs = Aws::CloudWatchLogs.new
   end
 
   def teardown
     clear_log_group
     FileUtils.rm_f(sequence_token_file)
   end
-  
+
 
   def test_configure
     d = create_driver(<<-EOC)
       type cloudwatch_logs
+      aws_key_id test_id
+      aws_sec_key test_key
+      region us-east-1
       log_group_name test_group
       log_stream_name test_stream
       sequence_token_file /tmp/sq
       auto_create_stream false
     EOC
 
+    assert_equal('test_id', d.instance.aws_key_id)
+    assert_equal('test_key', d.instance.aws_sec_key)
+    assert_equal('us-east-1', d.instance.region)
     assert_equal('test_group', d.instance.log_group_name)
     assert_equal('test_stream', d.instance.log_stream_name)
     assert_equal('/tmp/sq', d.instance.sequence_token_file)
@@ -41,7 +46,7 @@ class CloudwatchLogsOutputTest < Test::Unit::TestCase
     d.emit({'cloudwatch' => 'logs2'}, time.to_i + 1)
     d.run
 
-    sleep 5
+    sleep 20
 
     events = get_log_events
     assert_equal(2, events.size)
@@ -59,6 +64,9 @@ class CloudwatchLogsOutputTest < Test::Unit::TestCase
     log_stream_name #{log_stream_name}
     sequence_token_file #{sequence_token_file}
     auto_create_stream true
+    #{aws_key_id}
+    #{aws_sec_key}
+    #{region}
     EOC
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,11 +6,26 @@ require 'aws-sdk-core'
 module CloudwatchLogsTestHelper
   private
   def logs
-    @logs ||= Aws::CloudWatchLogs.new
+    options = {}
+    options[:credentials] = Aws::Credentials.new(ENV['aws_key_id'], ENV['aws_sec_key']) if ENV['aws_key_id'] && ENV['aws_sec_key']
+    options[:region] = ENV['region'] if ENV['region']
+    @logs ||= Aws::CloudWatchLogs.new(options)
   end
 
   def log_group_name
     @log_group_name ||= "fluent-plugin-cloudwatch-test-#{Time.now.to_f}"
+  end
+
+  def aws_key_id
+    "aws_key_id #{ENV['aws_key_id']}" if ENV['aws_key_id']
+  end
+
+  def aws_sec_key
+    "aws_sec_key #{ENV['aws_sec_key']}" if ENV['aws_sec_key']
+  end
+
+  def region
+    "region #{ENV['region']}" if ENV['region']
   end
 
   def log_stream_name
@@ -57,4 +72,3 @@ module CloudwatchLogsTestHelper
     logs.put_log_events(args)
   end
 end
-


### PR DESCRIPTION
Adds `aws_key_id`  and `aws_sec_key` (and `region` for future).
This is like options of fluent-plugin-s3(https://github.com/fluent/fluent-plugin-s3).
By this, We can collect some logs from multiple accounts, We can save some logs to multiple accounts,  and more.
