### PR TITLE
Fix create client

### DIFF
--- a/lib/fluent/plugin/in_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/in_cloudwatch_logs.rb
@@ -21,7 +21,7 @@ module Fluent
       options = {}
       options[:credentials] = Aws::Credentials.new(@aws_key_id, @aws_sec_key) if @aws_key_id && @aws_sec_key
       options[:region] = @region if @region
-      @logs = Aws::CloudWatchLogs.new(options)
+      @logs = Aws::CloudWatchLogs::Client.new(options)
 
       @finished = false
       @thread = Thread.new(&method(:run))

--- a/lib/fluent/plugin/out_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/out_cloudwatch_logs.rb
@@ -28,7 +28,7 @@ module Fluent
       options = {}
       options[:credentials] = Aws::Credentials.new(@aws_key_id, @aws_sec_key) if @aws_key_id && @aws_sec_key
       options[:region] = @region if @region
-      @logs = Aws::CloudWatchLogs.new(options)
+      @logs = Aws::CloudWatchLogs::Client.new(options)
 
       create_stream if @auto_create_stream
     end


### PR DESCRIPTION
`Aws::CloudWatchLogs.new deprecated as of v2.0.0.rc11 and will be removed as of v2.0.0.0 final; use Aws::CloudWatchLogs::Client.new() instead`とのことなので、クライアント生成方法を修正しました。
