### PR TITLE
Use Yajl for JSON encoding and decoding

### DIFF
--- a/fluent-plugin-cloudwatch-logs.gemspec
+++ b/fluent-plugin-cloudwatch-logs.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'fluentd'
+  spec.add_dependency 'yajl-ruby', '~> 1.0'
   spec.add_dependency 'aws-sdk-core', '>= 2.0.7'
   spec.add_dependency 'fluent-mixin-config-placeholders', '>= 0.2.0'
 

--- a/lib/fluent/plugin/in_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/in_cloudwatch_logs.rb
@@ -2,6 +2,8 @@ module Fluent
   require 'fluent/input'
   require 'fluent/mixin/config_placeholders'
 
+  require 'yajl'
+
   class CloudwatchLogsInput < Input
     Plugin.register_input('cloudwatch_logs', self)
 
@@ -108,7 +110,7 @@ module Fluent
         router.emit(@tag, record[0], record[1])
       else
         time = (event.timestamp / 1000).floor
-        record = JSON.parse(event.message)
+        record = Yajl.load(event.message)
         router.emit(@tag, time, record)
       end
     end

--- a/lib/fluent/plugin/in_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/in_cloudwatch_logs.rb
@@ -1,4 +1,5 @@
 module Fluent
+  require 'fluent/input'
   require 'fluent/mixin/config_placeholders'
 
   class CloudwatchLogsInput < Input

--- a/lib/fluent/plugin/out_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/out_cloudwatch_logs.rb
@@ -1,6 +1,8 @@
 module Fluent
   require 'fluent/mixin/config_placeholders'
 
+  require 'yajl'
+
   class CloudwatchLogsOutput < BufferedOutput
     Plugin.register_output('cloudwatch_logs', self)
 
@@ -130,7 +132,7 @@ module Fluent
           if @message_keys
             message = @message_keys.split(',').map {|k| record[k].to_s }.join(' ')
           else
-            message = record.to_json
+            message = Yajl.dump(record)
           end
 
           if @max_message_length

--- a/test/plugin/test_out_cloudwatch_logs.rb
+++ b/test/plugin/test_out_cloudwatch_logs.rb
@@ -1,5 +1,8 @@
+# coding: utf-8
 require 'test_helper'
 require 'fileutils'
+
+require 'yajl'
 
 class CloudwatchLogsOutputTest < Test::Unit::TestCase
   include CloudwatchLogsTestHelper
@@ -278,13 +281,13 @@ class CloudwatchLogsOutputTest < Test::Unit::TestCase
     assert_equal(2, events.size)
     assert_equal(time.to_i * 1000, events[0].timestamp)
     assert_equal((time.to_i + 2) * 1000, events[1].timestamp)
-    assert_equal(records[0], JSON.parse(events[0].message))
-    assert_equal(records[2], JSON.parse(events[1].message))
+    assert_equal(records[0], Yajl.load(events[0].message))
+    assert_equal(records[2], Yajl.load(events[1].message))
 
     events = get_log_events(log_group_name, stream2)
     assert_equal(1, events.size)
     assert_equal((time.to_i + 1) * 1000, events[0].timestamp)
-    assert_equal(records[1], JSON.parse(events[0].message))
+    assert_equal(records[1], Yajl.load(events[0].message))
   end
 
   def test_remove_log_group_name_key_and_remove_log_stream_name_key
@@ -307,7 +310,7 @@ class CloudwatchLogsOutputTest < Test::Unit::TestCase
     events = get_log_events(log_group_name, log_stream_name)
     assert_equal(1, events.size)
     assert_equal(time.to_i * 1000, events[0].timestamp)
-    assert_equal({'cloudwatch' => 'logs1', 'message' => 'message1'}, JSON.parse(events[0].message))
+    assert_equal({'cloudwatch' => 'logs1', 'message' => 'message1'}, Yajl.load(events[0].message))
   end
 
   def test_retrying_on_throttling_exception


### PR DESCRIPTION
It seems like the standard JSON module is very picky about encodings in messages. Yajl seems to be a lot easier on the message encoding.

This fixes issues like #38 for us in production.