### PR TITLE
Add `endpoint` parameter to allow users to mock out AWS APIs.

### DIFF
--- a/lib/fluent/plugin/in_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/in_cloudwatch_logs.rb
@@ -13,6 +13,7 @@ module Fluent::Plugin
     config_param :aws_sts_role_arn, :string, default: nil
     config_param :aws_sts_session_name, :string, default: 'fluentd'
     config_param :region, :string, :default => nil
+    config_param :endpoint, :string, :default => nil
     config_param :tag, :string
     config_param :log_group_name, :string
     config_param :log_stream_name, :string
@@ -41,6 +42,7 @@ module Fluent::Plugin
       super
       options = {}
       options[:region] = @region if @region
+      options[:endpoint] = @endpoint if @endpoint
       options[:http_proxy] = @http_proxy if @http_proxy
 
       if @aws_use_sts

--- a/lib/fluent/plugin/out_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/out_cloudwatch_logs.rb
@@ -15,6 +15,7 @@ module Fluent::Plugin
     config_param :aws_sts_role_arn, :string, default: nil
     config_param :aws_sts_session_name, :string, default: 'fluentd'
     config_param :region, :string, :default => nil
+    config_param :endpoint, :string, :default => nil
     config_param :log_group_name, :string, :default => nil
     config_param :log_stream_name, :string, :default => nil
     config_param :auto_create_stream, :bool, default: false
@@ -79,6 +80,7 @@ module Fluent::Plugin
 
       options = {}
       options[:region] = @region if @region
+      options[:endpoint] = @endpoint if @endpoint
 
       if @aws_use_sts
         Aws.config[:region] = options[:region]

--- a/test/plugin/test_in_cloudwatch_logs.rb
+++ b/test/plugin/test_in_cloudwatch_logs.rb
@@ -80,6 +80,7 @@ class CloudwatchLogsInputTest < Test::Unit::TestCase
       #{aws_key_id}
       #{aws_sec_key}
       #{region}
+      #{endpoint}
     EOC
 
     d.run(expect_emits: 2, timeout: 5)
@@ -123,6 +124,7 @@ class CloudwatchLogsInputTest < Test::Unit::TestCase
       #{aws_key_id}
       #{aws_sec_key}
       #{region}
+      #{endpoint}
     EOC
     d.run(expect_emits: 4, timeout: 5)
 
@@ -146,6 +148,7 @@ class CloudwatchLogsInputTest < Test::Unit::TestCase
       #{aws_key_id}
       #{aws_sec_key}
       #{region}
+      #{endpoint}
     EOC
   end
 

--- a/test/plugin/test_out_cloudwatch_logs.rb
+++ b/test/plugin/test_out_cloudwatch_logs.rb
@@ -607,6 +607,7 @@ auto_create_stream true
 #{aws_key_id}
 #{aws_sec_key}
 #{region}
+#{endpoint}
     EOC
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,6 +11,7 @@ module CloudwatchLogsTestHelper
     options = {}
     options[:credentials] = Aws::Credentials.new(ENV['aws_key_id'], ENV['aws_sec_key']) if ENV['aws_key_id'] && ENV['aws_sec_key']
     options[:region] = ENV['region'] if ENV['region']
+    options[:endpoint] = ENV['endpoint'] if ENV['endpoint']
     options[:http_proxy] = ENV['http_proxy'] if ENV['http_proxy']
     @logs ||= Aws::CloudWatchLogs::Client.new(options)
   end
@@ -29,6 +30,10 @@ module CloudwatchLogsTestHelper
 
   def region
     "region #{ENV['region']}" if ENV['region']
+  end
+
+  def endpoint
+    "endpoint #{ENV['endpoint']}" if ENV['endpoint']
   end
 
   def log_stream_name(log_stream_name_prefix = nil)


### PR DESCRIPTION
### What's this patch?

This new options allows developers to run this plugin against a mock
AWS server (like moto). For example, if the mock server is running
on `localhost:5000`, you can connect to the server (instead of the
production AWS server) with the following settings:

    <source>
      @type cloudwatch_logs
      tag debug.log
      endpoint http://localhost:5000
      ...
    </source>

This should come in very handy especially when tinkering the features
of the plugin.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>