### PR TITLE
test: Fix random test failures caused by undefined sort order

### DIFF
--- a/test/plugin/test_in_cloudwatch_logs.rb
+++ b/test/plugin/test_in_cloudwatch_logs.rb
@@ -100,15 +100,15 @@ class CloudwatchLogsInputTest < Test::Unit::TestCase
 
     time_ms = (Time.now.to_f * 1000).floor
     put_log_events([
-      {timestamp: time_ms, message: '{"cloudwatch":"logs1"}'},
-      {timestamp: time_ms, message: '{"cloudwatch":"logs2"}'},
+      {timestamp: time_ms + 10, message: '{"cloudwatch":"logs1"}'},
+      {timestamp: time_ms + 20, message: '{"cloudwatch":"logs2"}'},
     ])
 
     new_log_stream("testprefix")
     create_log_stream
     put_log_events([
-      {timestamp: time_ms, message: '{"cloudwatch":"logs3"}'},
-      {timestamp: time_ms, message: '{"cloudwatch":"logs4"}'},
+      {timestamp: time_ms + 30, message: '{"cloudwatch":"logs3"}'},
+      {timestamp: time_ms + 40, message: '{"cloudwatch":"logs4"}'},
     ])
 
     sleep 5
@@ -128,10 +128,10 @@ class CloudwatchLogsInputTest < Test::Unit::TestCase
 
     emits = d.events
     assert_equal(4, emits.size)
-    assert_equal(['test', (time_ms / 1000).floor, {'cloudwatch' => 'logs1'}], emits[0])
-    assert_equal(['test', (time_ms / 1000).floor, {'cloudwatch' => 'logs2'}], emits[1])
-    assert_equal(['test', (time_ms / 1000).floor, {'cloudwatch' => 'logs3'}], emits[2])
-    assert_equal(['test', (time_ms / 1000).floor, {'cloudwatch' => 'logs4'}], emits[3])
+    assert_equal(['test', ((time_ms + 10) / 1000).floor, {'cloudwatch' => 'logs1'}], emits[0])
+    assert_equal(['test', ((time_ms + 20) / 1000).floor, {'cloudwatch' => 'logs2'}], emits[1])
+    assert_equal(['test', ((time_ms + 30) / 1000).floor, {'cloudwatch' => 'logs3'}], emits[2])
+    assert_equal(['test', ((time_ms + 40) / 1000).floor, {'cloudwatch' => 'logs4'}], emits[3])
   end
 
   private


### PR DESCRIPTION
### Problem

The function test_emit_with_prefix() assumes that, if several log
events have the same timestamp, they are returned in the original
insertion order. This is not always so.

This misassumption can cause test failures like below:

```python
./test/plugin/test_in_cloudwatch_logs.rb:133:in `test_emit_with_prefix'
     130:
     131:     emits = d.events
     132:     assert_equal(4, emits.size)
  => 133:     assert_equal(['test', (time_ms / 1000).floor, {'cloudwatch' => 'logs1'}], emits[0])
     134:     assert_equal(['test', (time_ms / 1000).floor, {'cloudwatch' => 'logs2'}], emits[1])
     135:     assert_equal(['test', (time_ms / 1000).floor, {'cloudwatch' => 'logs3'}], emits[2])
     136:     assert_equal(['test', (time_ms / 1000).floor, {'cloudwatch' => 'logs4'}], emits[3])
<["test", 1524545042, {"cloudwatch"=>"logs1"}]> expected but was
<["test", 1524545042, {"cloudwatch"=>"logs3"}]>

diff:
? ["test", 1524545042, {"cloudwatch"=>"logs1"}]
?                                          3
Failure: test_emit_with_prefix(CloudwatchLogsInputTest)
```


### Solution

This patch fixes the issue described above by differentiating the timestamps of test data
records, which should ensure the order of returned records.