### PR TITLE
Add an option to select the JSON library to use (JSON/Yajl)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Fetch sample log from CloudWatch Logs:
   #put_log_events_retry_limit 17
   #put_log_events_disable_retry_limit false
   #endpoint http://localhost:5000/
+  #json_handler json
 </match>
 ```
 
@@ -104,6 +105,7 @@ Fetch sample log from CloudWatch Logs:
 * `put_log_events_retry_limit`: maximum count of retry (if exceeding this, the events will be discarded)
 * `put_log_events_disable_retry_limit`: if true, `put_log_events_retry_limit` will be ignored
 * `endpoint`: use this parameter to connect to the local API endpoint (for testing)
+* `json_handler`: name of the library to be used to handle JSON data. For now, supported libraries are `json` (default) and `yajl`.
 
 ### in_cloudwatch_logs
 
@@ -116,6 +118,7 @@ Fetch sample log from CloudWatch Logs:
   #use_log_stream_name_prefix true
   state_file /var/lib/fluent/group_stream.in.state
   #endpoint http://localhost:5000/
+  #json_handler json
 </source>
 ```
 
@@ -128,6 +131,7 @@ Fetch sample log from CloudWatch Logs:
 * `aws_use_sts`: use [AssumeRoleCredentials](http://docs.aws.amazon.com/sdkforruby/api/Aws/AssumeRoleCredentials.html) to authenticate, rather than the [default credential hierarchy](http://docs.aws.amazon.com/sdkforruby/api/Aws/CloudWatchLogs/Client.html#initialize-instance_method). See 'Cross-Account Operation' below for more detail.
 * `aws_sts_role_arn`: the role ARN to assume when using cross-account sts authentication
 * `aws_sts_session_name`: the session name to use with sts authentication (default: `fluentd`)
+* `json_handler`:  name of the library to be used to handle JSON data. For now, supported libraries are `json` (default) and `yajl`.
 
 This plugin uses [fluent-mixin-config-placeholders](https://github.com/tagomoris/fluent-mixin-config-placeholders) and you can use addtional variables such as %{hostname}, %{uuid}, etc. These variables are useful to put hostname in `log_stream_name`.
 

--- a/test/plugin/test_in_cloudwatch_logs.rb
+++ b/test/plugin/test_in_cloudwatch_logs.rb
@@ -37,6 +37,7 @@ class CloudwatchLogsInputTest < Test::Unit::TestCase
     assert_equal('stream', d.instance.log_stream_name)
     assert_equal(true, d.instance.use_log_stream_name_prefix)
     assert_equal('/tmp/state', d.instance.state_file)
+    assert_equal(:json, d.instance.json_handler)
   end
 
   def test_emit

--- a/test/plugin/test_out_cloudwatch_logs.rb
+++ b/test/plugin/test_out_cloudwatch_logs.rb
@@ -40,6 +40,7 @@ class CloudwatchLogsOutputTest < Test::Unit::TestCase
     assert_equal("tagvalue", d.instance.log_group_aws_tags.fetch("tagkey"))
     assert_equal("tagvalue_2", d.instance.log_group_aws_tags.fetch("tagkey_2"))
     assert_equal(5, d.instance.retention_in_days)
+    assert_equal(:json, d.instance.json_handler)
   end
 
   def test_write


### PR DESCRIPTION
### Overview

This patch adds a configurable parameter which enables developers to
choose their preferable JSON library. This option should be useful to
mitigate the encoding-related errors, which are apparently caused by
the subtle implementation difference in the JSON libraries.

For now, it only supports the following two libraries: JSON (which is
the default choice) and Yajl, but it should be fairly trivial to add
other options here.

### Note

For the background discussion of this patch, please read #58.