### PR TITLE
Enable using placeholders

### DIFF
--- a/lib/fluent/plugin/out_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/out_cloudwatch_logs.rb
@@ -121,6 +121,8 @@ module Fluent::Plugin
 
     def write(chunk)
       @log_group_name = extract_placeholders(@log_group_name, chunk)
+      @log_stream_name = extract_placeholders(@log_stream_name, chunk)
+
       queue = Thread::Queue.new
 
       chunk.enum_for(:msgpack_each).select {|tag, time, record|

--- a/lib/fluent/plugin/out_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/out_cloudwatch_logs.rb
@@ -120,6 +120,7 @@ module Fluent::Plugin
     end
 
     def write(chunk)
+      @log_group_name = extract_placeholders(@log_group_name, chunk)
       queue = Thread::Queue.new
 
       chunk.enum_for(:msgpack_each).select {|tag, time, record|


### PR DESCRIPTION
fix: https://github.com/fluent-plugins-nursery/fluent-plugin-cloudwatch-logs/issues/93

I've tried to add placeholder support for `log_group_name` and `log_stream_name` .

#### NOTES
I tested like below:

```rb
<match test.hoge>
  @type cloudwatch_logs
  log_group_name ${tag}
  log_stream_name ${tag}
  auto_create_stream true

  <buffer tag>
  </buffer>
</match>

<match test.cloudwatch_logs.in>
  @type stdout
</match>
```

```sh
echo '{"status":"OK"}' | fluent-cat test.hoge
```