### PR TITLE
Use yajl as default JSON serializer/deserializer

### DIFF
--- a/lib/fluent/plugin/in_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/in_cloudwatch_logs.rb
@@ -22,7 +22,7 @@ module Fluent::Plugin
     config_param :state_file, :string
     config_param :fetch_interval, :time, default: 60
     config_param :http_proxy, :string, default: nil
-    config_param :json_handler, :enum, list: [:yajl, :json], :default => :json
+    config_param :json_handler, :enum, list: [:yajl, :json], :default => :yajl
 
     config_section :parse do
       config_set_default :@type, 'none'

--- a/lib/fluent/plugin/out_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/out_cloudwatch_logs.rb
@@ -42,7 +42,7 @@ module Fluent::Plugin
     config_param :retention_in_days, :integer, default: nil
     config_param :retention_in_days_key, :string, default: nil
     config_param :remove_retention_in_days, :bool, default: false
-    config_param :json_handler, :enum, list: [:yajl, :json], :default => :json
+    config_param :json_handler, :enum, list: [:yajl, :json], :default => :yajl
 
     config_section :buffer do
       config_set_default :@type, DEFAULT_BUFFER_TYPE

--- a/test/plugin/test_in_cloudwatch_logs.rb
+++ b/test/plugin/test_in_cloudwatch_logs.rb
@@ -37,7 +37,7 @@ class CloudwatchLogsInputTest < Test::Unit::TestCase
     assert_equal('stream', d.instance.log_stream_name)
     assert_equal(true, d.instance.use_log_stream_name_prefix)
     assert_equal('/tmp/state', d.instance.state_file)
-    assert_equal(:json, d.instance.json_handler)
+    assert_equal(:yajl, d.instance.json_handler)
   end
 
   def test_emit

--- a/test/plugin/test_out_cloudwatch_logs.rb
+++ b/test/plugin/test_out_cloudwatch_logs.rb
@@ -40,7 +40,7 @@ class CloudwatchLogsOutputTest < Test::Unit::TestCase
     assert_equal("tagvalue", d.instance.log_group_aws_tags.fetch("tagkey"))
     assert_equal("tagvalue_2", d.instance.log_group_aws_tags.fetch("tagkey_2"))
     assert_equal(5, d.instance.retention_in_days)
-    assert_equal(:json, d.instance.json_handler)
+    assert_equal(:yajl, d.instance.json_handler)
   end
 
   def test_write


### PR DESCRIPTION
Fluentd uses Yajl as default JSON serializer/deserializer.

Until now, fluent-plugin-cloudwatch-logs uses JSON as default serializer/deserializer.
It causes encoding error when converting encoding ASCII-8bit to UTF-8.
Yajl is robust encoder under a above situation.
Let's use Yajl as default JSON encoder/decoder.