### PR TITLE
cloudwatch input InvalidParameterException fix and use_todays_log_stream param

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Fetch sample log from CloudWatch Logs:
 * `aws_sts_role_arn`: the role ARN to assume when using cross-account sts authentication
 * `aws_sts_session_name`: the session name to use with sts authentication (default: `fluentd`)
 * `json_handler`:  name of the library to be used to handle JSON data. For now, supported libraries are `json` (default) and `yajl`.
+* `use_todays_log_stream`: use todays date as log stream name prefix (formatted YYYY/MM/DD). (default: `false`)
 
 This plugin uses [fluent-mixin-config-placeholders](https://github.com/tagomoris/fluent-mixin-config-placeholders) and you can use addtional variables such as %{hostname}, %{uuid}, etc. These variables are useful to put hostname in `log_stream_name`.
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Fetch sample log from CloudWatch Logs:
 * `aws_sts_role_arn`: the role ARN to assume when using cross-account sts authentication
 * `aws_sts_session_name`: the session name to use with sts authentication (default: `fluentd`)
 * `json_handler`:  name of the library to be used to handle JSON data. For now, supported libraries are `json` (default) and `yajl`.
-* `use_todays_log_stream`: use todays date as log stream name prefix (formatted YYYY/MM/DD). (default: `false`)
+* `use_todays_log_stream`: use todays and yesterdays date as log stream name prefix (formatted YYYY/MM/DD). (default: `false`)
 
 This plugin uses [fluent-mixin-config-placeholders](https://github.com/tagomoris/fluent-mixin-config-placeholders) and you can use addtional variables such as %{hostname}, %{uuid}, etc. These variables are useful to put hostname in `log_stream_name`.
 

--- a/lib/fluent/plugin/cloudwatch/logs/version.rb
+++ b/lib/fluent/plugin/cloudwatch/logs/version.rb
@@ -2,7 +2,7 @@ module Fluent
   module Plugin
     module Cloudwatch
       module Logs
-        VERSION = "0.6.0"
+        VERSION = "0.0.5"
       end
     end
   end

--- a/lib/fluent/plugin/cloudwatch/logs/version.rb
+++ b/lib/fluent/plugin/cloudwatch/logs/version.rb
@@ -2,7 +2,7 @@ module Fluent
   module Plugin
     module Cloudwatch
       module Logs
-        VERSION = "0.0.5"
+        VERSION = "0.6.0"
       end
     end
   end

--- a/test/plugin/test_in_cloudwatch_logs.rb
+++ b/test/plugin/test_in_cloudwatch_logs.rb
@@ -163,15 +163,15 @@ class CloudwatchLogsInputTest < Test::Unit::TestCase
     new_log_stream(yesterday)
     create_log_stream
     put_log_events([
-      {timestamp: time_ms + 3000, message: '{"cloudwatch":"logs5"}'},
-      {timestamp: time_ms + 4000, message: '{"cloudwatch":"logs6"}'},
+      {timestamp: time_ms + 5000, message: '{"cloudwatch":"logs5"}'},
+      {timestamp: time_ms + 6000, message: '{"cloudwatch":"logs6"}'},
     ])
 
     new_log_stream(tomorrow)
     create_log_stream
     put_log_events([
-      {timestamp: time_ms + 3000, message: '{"cloudwatch":"logs7"}'},
-      {timestamp: time_ms + 4000, message: '{"cloudwatch":"logs8"}'},
+      {timestamp: time_ms + 7000, message: '{"cloudwatch":"logs7"}'},
+      {timestamp: time_ms + 8000, message: '{"cloudwatch":"logs8"}'},
     ])
 
     sleep 5
@@ -191,8 +191,14 @@ class CloudwatchLogsInputTest < Test::Unit::TestCase
 
     emits = d.events
     assert_equal(2, emits.size)
+    assert_false(emits.include? ['test', ((time_ms + 1000) / 1000).floor, {'cloudwatch' => 'logs1'}])
+    assert_false(emits.include? ['test', ((time_ms + 2000) / 1000).floor, {'cloudwatch' => 'logs2'}])
     assert_true(emits.include? ['test', ((time_ms + 3000) / 1000).floor, {'cloudwatch' => 'logs3'}])
     assert_true(emits.include? ['test', ((time_ms + 4000) / 1000).floor, {'cloudwatch' => 'logs4'}])
+    assert_false(emits.include? ['test', ((time_ms + 5000) / 1000).floor, {'cloudwatch' => 'logs5'}])
+    assert_false(emits.include? ['test', ((time_ms + 6000) / 1000).floor, {'cloudwatch' => 'logs6'}])
+    assert_false(emits.include? ['test', ((time_ms + 7000) / 1000).floor, {'cloudwatch' => 'logs7'}])
+    assert_false(emits.include? ['test', ((time_ms + 8000) / 1000).floor, {'cloudwatch' => 'logs8'}])
   end
 
   private

--- a/test/plugin/test_in_cloudwatch_logs.rb
+++ b/test/plugin/test_in_cloudwatch_logs.rb
@@ -138,7 +138,7 @@ class CloudwatchLogsInputTest < Test::Unit::TestCase
     assert_true(emits.include? ['test', ((time_ms + 4000) / 1000).floor, {'cloudwatch' => 'logs4'}])
   end
 
-  def test_emit_with_todays_log_Stream
+  def test_emit_with_todays_log_stream
     new_log_stream("testprefix")
     create_log_stream
 


### PR DESCRIPTION
- fix to issue #116 by adding condition to check if next token is empty before sending

- added condition to check if next token changed before serializing it

- added `use_todays_log_stream` option to use todays date as log stream name prefix (`YYYY/MM/DD`). This is useful for pulling logs created by lambdas