### PR TITLE
Extract subpath for log_group_name_key/log_stream_name_key

### DIFF
--- a/lib/fluent/plugin/out_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/out_cloudwatch_logs.rb
@@ -122,6 +122,14 @@ module Fluent::Plugin
       true
     end
 
+    def get_path(paths, record)
+      curr = record
+      paths.split('.').each do |path|
+        curr = curr[path]
+      end
+      curr
+    end
+
     def write(chunk)
       queue = Thread::Queue.new
 
@@ -140,7 +148,7 @@ module Fluent::Plugin
                   if @remove_log_group_name_key
                     record.delete(@log_group_name_key)
                   else
-                    record[@log_group_name_key]
+                    get_path(@log_group_name_key, record)
                   end
                 else
                   @log_group_name
@@ -153,7 +161,7 @@ module Fluent::Plugin
                    if @remove_log_stream_name_key
                      record.delete(@log_stream_name_key)
                    else
-                     record[@log_stream_name_key]
+                     get_path(@log_stream_name_key, record)
                    end
                  else
                    @log_stream_name


### PR DESCRIPTION
When using with `type kubernetes_metadata`. I'd like to extract values from subpath such as:

log_group_name_key "kubernetes.labels.name"
log_stream_name_key "kubernetes.pod_name"

kubernetes_metadata
```
{
    "log": "_",
    "stream": "_",
    "docker": {
      "container_id": "_"
    },
    "kubernetes": {
      "container_name": "_",
      "namespace_name": "_",
      "pod_name": "_",
      "pod_id": "_",
      "labels": {
        "name": "_",
        "pod-template-hash": "_"
      },
      "host": "_",
      "master_url": "_",
      "namespace_id": "_",
      "namespace_labels": {
        "name": "_"
      }
    }
}
```