### PR TITLE
Allow Log group prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@
 
 ## Requirements
 
-|fluent-plugin-cloudwatch-logs|     fluentd      |  ruby  |
-|-----------------------------|------------------|--------|
-|     >= 0.5.0                | >= 0.14.15       | >= 2.1 |
-|     <= 0.4.5                | ~> 0.12.0 *      | >= 1.9 |
+| fluent-plugin-cloudwatch-logs | fluentd     | ruby   |
+| ----------------------------- | ----------- | ------ |
+| >= 0.5.0                      | >= 0.14.15  | >= 2.1 |
+| <= 0.4.5                      | ~> 0.12.0 * | >= 1.9 |
 
 * May not support all future fluentd features
 
@@ -141,6 +141,7 @@ Fetch sample log from CloudWatch Logs:
 </source>
 ```
 
+* `add_log_group_name`: adds the log_group_name to the record with key `log_group_name_key` (default: `false`)
 * `aws_sts_role_arn`: the role ARN to assume when using cross-account sts authentication
 * `aws_sts_session_name`: the session name to use with sts authentication (default: `fluentd`)
 * `aws_use_sts`: use [AssumeRoleCredentials](http://docs.aws.amazon.com/sdkforruby/api/Aws/AssumeRoleCredentials.html) to authenticate, rather than the [default credential hierarchy](http://docs.aws.amazon.com/sdkforruby/api/Aws/CloudWatchLogs/Client.html#initialize-instance_method). See 'Cross-Account Operation' below for more detail.
@@ -149,10 +150,12 @@ Fetch sample log from CloudWatch Logs:
 * `http_proxy`: use to set an optional HTTP proxy
 * `json_handler`:  name of the library to be used to handle JSON data. For now, supported libraries are `json` (default) and `yajl`.
 * `log_group_name`: name of log group to fetch logs
+* `log_group_name_key`: key to use when `add_log_group_name` is set (default: `log_group`)
 * `log_stream_name`: name of log stream to fetch logs
 * `state_file`: file to store current state (e.g. next\_forward\_token)
 * `tag`: fluentd tag
-* `use_log_stream_name_prefix`: to use `log_stream_name` as log stream name prefix (default false)
+* `use_log_group_name_prefix`: to use `log_group_name` as log group name prefix (default `false`)
+* `use_log_stream_name_prefix`: to use `log_stream_name` as log stream name prefix (default `false`)
 * `use_todays_log_stream`: use todays and yesterdays date as log stream name prefix (formatted YYYY/MM/DD). (default: `false`)
 
 ## Test

--- a/example/fluentd_log_group_prefix.conf
+++ b/example/fluentd_log_group_prefix.conf
@@ -7,6 +7,7 @@
   tag test.cloudwatch_logs.in
   use_log_group_name_prefix true
   log_group_name /aws/lambda/
+  add_log_group_name true
   use_log_stream_name_prefix true
   log_stream_name 2019/02
   state_file /tmp/fluent-plugin-cloudwatch-example.state

--- a/example/fluentd_log_group_prefix.conf
+++ b/example/fluentd_log_group_prefix.conf
@@ -1,0 +1,32 @@
+<source>
+  @type forward
+</source>
+
+<source>
+  @type cloudwatch_logs
+  tag test.cloudwatch_logs.in
+  use_log_group_name_prefix true
+  log_group_name /aws/lambda/
+  use_log_stream_name_prefix true
+  log_stream_name 2019/02
+  state_file /tmp/fluent-plugin-cloudwatch-example.state
+
+  format none
+
+  <parse>
+    @type none
+    message_key log
+  </parse>
+</source>
+
+<match test.cloudwatch_logs.out>
+  @type cloudwatch_logs
+  log_group_name fluent-plugin-cloudwatch-example
+  log_stream_name fluent-plugin-cloudwatch-example
+  auto_create_stream true
+</match>
+
+<match test.cloudwatch_logs.in>
+  @type stdout
+</match>
+

--- a/lib/fluent/plugin/in_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/in_cloudwatch_logs.rb
@@ -111,13 +111,12 @@ module Fluent::Plugin
           @next_fetch_time += @fetch_interval
 
           if @use_log_group_name_prefix
-            log_groups = describe_log_groups(@log_group_name)
+            log_group_names = describe_log_groups(@log_group_name).map{|log_group| log_group.log_group_name}
           else
-            log_groups = [@log_group_name]
+            log_group_names = [@log_group_name]
           end
 
-          log_groups.each do |log_group|
-            log_group_name = log_group.log_group_name
+          log_group_names.each do |log_group_name|
             if @use_log_stream_name_prefix || @use_todays_log_stream
               log_stream_name_prefix = @use_todays_log_stream ? get_todays_date : @log_stream_name
               begin
@@ -172,7 +171,7 @@ module Fluent::Plugin
         log_stream_name: log_stream_name
       }
       log_next_token = next_token(log_group_name, log_stream_name)
-      request[:next_token] = log_next_token if !log_next_token.nil? && !log_next_token.empty? 
+      request[:next_token] = log_next_token if !log_next_token.nil? && !log_next_token.empty?
       response = @logs.get_log_events(request)
       if valid_next_token(log_next_token, response.next_forward_token)
         store_next_token(response.next_forward_token, log_group_name, log_stream_name)
@@ -198,7 +197,7 @@ module Fluent::Plugin
       end
       log_streams
     end
-    
+
     def describe_log_groups(log_group_name_prefix, log_groups = nil, next_token = nil)
       request = {
         log_group_name_prefix: log_group_name_prefix


### PR DESCRIPTION
Adding `use_log_group_prefix` for using `log_group_name` as a prefix to match several groups.

Lambda, RDS and other PaaS services generate log groups and this allows to ingest them all.

Also adding `add_log_group_name` and `log_group_name_key` for writing the log group name to the record and being able to distinguish them later.

A new example is provided.