### PR TITLE
Add date prefix to output plugin's log_stream_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ Fetch sample log from CloudWatch Logs:
   #max_message_length 32768
   #use_tag_as_group false
   #use_tag_as_stream false
+  #use_todays_log_stream_prefix false
+  #use_todays_log_stream_prefix_format %Y%m%d
   #include_time_key true
   #localtime true
   #log_group_name_key group_name_key
@@ -125,6 +127,8 @@ Fetch sample log from CloudWatch Logs:
 * `retention_in_days_key`: use specified field of records as retention period
 * `use_tag_as_group`: to use tag as a group name
 * `use_tag_as_stream`: to use tag as a stream name
+* `use_todays_log_stream_prefix`: to use date prefix as a stream name (default false)
+* `use_todays_log_stream_prefix_format`:  to use date prefix format as a stream name (default empty)
 
 ### in_cloudwatch_logs
 

--- a/lib/fluent/plugin/out_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/out_cloudwatch_logs.rb
@@ -1,3 +1,4 @@
+require 'date'
 require 'fluent/plugin/output'
 require 'thread'
 require 'yajl'
@@ -44,6 +45,8 @@ module Fluent::Plugin
     config_param :remove_retention_in_days, :bool, default: false
     config_param :json_handler, :enum, list: [:yajl, :json], :default => :yajl
     config_param :log_rejected_request, :bool, :default => false
+    config_param :use_todays_log_stream_prefix, :bool, default: false
+    config_param :use_todays_log_stream_prefix_format, :string, default: nil
 
     config_section :buffer do
       config_set_default :@type, DEFAULT_BUFFER_TYPE
@@ -124,6 +127,8 @@ module Fluent::Plugin
     end
 
     def write(chunk)
+      @log_stream_name = get_todays_date + @log_stream_name if @use_todays_log_stream_prefix
+
       log_group_name = extract_placeholders(@log_group_name, chunk) if @log_group_name
       log_stream_name = extract_placeholders(@log_stream_name, chunk) if @log_stream_name
 
@@ -465,6 +470,11 @@ module Fluent::Plugin
         sleep 0.1
       end
       nil
+    end
+
+    def get_todays_date
+      @use_todays_log_stream_prefix_format ||=  "%Y/%m/%d"
+      return Date.today.strftime(@use_todays_log_stream_prefix_format)
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -102,4 +102,8 @@ module CloudwatchLogsTestHelper
     }
     logs.put_log_events(args)
   end
+
+  def get_todays_date(format = "%Y/%m/%d")
+    return Date.today.strftime(format)
+  end
 end


### PR DESCRIPTION
Add date prefix to log_stream_name: use_todays_log_stream_prefix and use_todays_log_stream_prefix_format

Note
This change does not affect any existing programs.
