### PR TITLE
Force encoding to UTF-8 when scrubbing

### DIFF
--- a/lib/fluent/plugin/out_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/out_cloudwatch_logs.rb
@@ -259,6 +259,9 @@ module Fluent::Plugin
       when Array
         record.each {|v| scrub_record!(v) }
       when String
+        # The AWS API requires UTF-8 encoding
+        # https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CloudWatchLogsConcepts.html
+        record.force_encoding('UTF-8')
         record.scrub!
       end
     end


### PR DESCRIPTION
This PR adds a force_encoding to the scrub_record! method to force encoding to UTF-8.  This is needed because Fluentd forces ASCII-8bit encoding [in the supervisor](https://github.com/fluent/fluentd/blob/08a31d20c0f6158b2d804ea5bac131938d8c5551/lib/fluent/supervisor.rb#L605), however CloudWatch [requires events to be UTF-8 encoded](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CloudWatchLogsConcepts.html).  As ASCII-8Bit and UTF-8 have incompatible characters scrubbing on ASCII-8bit characters can still result in encoding errors.  This change resolves encoding issues like #152 

I did not include tests as the test suite is failing on master for me, and I'm not familiar with the test framework in use to work around that.