### PR TITLE
Add support for ingesting non-JSON messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ tmp
 *.o
 *.a
 mkmf.log
+.idea
+*.iml

--- a/lib/fluent/plugin/in_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/in_cloudwatch_logs.rb
@@ -144,14 +144,14 @@ module Fluent::Plugin
           router.emit(@tag, time, record)
         }
       else
+        time = (event.timestamp / 1000).floor
         begin
           record = @json_handler.load(event.message)
-        rescue JSON::ParserError, Yajl::ParseError # Catch parser errors
-          log.debug "Non-JSON message encountered"
-          record = { message: event.message }
+          router.emit(@tag, time, record)
+        rescue JSON::ParserError, Yajl::ParseError => error # Catch parser errors
+          log.error "Invalid JSON encountered while parsing event.message"
+          router.emit_error_event(@tag, time, { message: event.message }, error)
         end
-        time = (event.timestamp / 1000).floor
-        router.emit(@tag, time, record)
       end
     end
 

--- a/lib/fluent/plugin/in_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/in_cloudwatch_logs.rb
@@ -144,8 +144,13 @@ module Fluent::Plugin
           router.emit(@tag, time, record)
         }
       else
+        begin
+          record = @json_handler.load(event.message)
+        rescue JSON::ParserError, Yajl::ParseError # Catch parser errors
+          log.debug "Non-JSON message encountered"
+          record = { message: event.message }
+        end
         time = (event.timestamp / 1000).floor
-        record = @json_handler.load(event.message)
         router.emit(@tag, time, record)
       end
     end


### PR DESCRIPTION
Non-JSON messages in CloudWatch caused the plugin to crash and burn. This PR adds a `begin/rescue` block to properly deal with them by wrapping non-JSON events into a hash as per the Fluentd event spec.

Fixes #156 