### PR TITLE
Fix a typo of the description

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Fetch sample log from CloudWatch Logs:
 * `remove_log_group_aws_tags_key`: remove field specified by `log_group_aws_tags_key`
 * `remove_log_group_name_key`: remove field specified by `log_group_name_key`
 * `remove_log_stream_name_key`: remove field specified by `log_stream_name_key`
-* `remove_retention_in_days`: remove field specified by `retention_in_days`
+* `remove_retention_in_days`: remove field specified by `retention_in_days_key`
 * `retention_in_days`: use to set the expiry time for log group when created with `auto_create_stream`. (default to no expiry)
 * `retention_in_days_key`: use specified field of records as retention period
 * `use_tag_as_group`: to use tag as a group name

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Fetch sample log from CloudWatch Logs:
 * `remove_log_group_aws_tags_key`: remove field specified by `log_group_aws_tags_key`
 * `remove_log_group_name_key`: remove field specified by `log_group_name_key`
 * `remove_log_stream_name_key`: remove field specified by `log_stream_name_key`
-* `remove_retention_in_days`: remove field specified by `retention_in_days_key`
+* `remove_retention_in_days_key`: remove field specified by `retention_in_days_key`
 * `retention_in_days`: use to set the expiry time for log group when created with `auto_create_stream`. (default to no expiry)
 * `retention_in_days_key`: use specified field of records as retention period
 * `use_tag_as_group`: to use tag as a group name

--- a/lib/fluent/plugin/out_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/out_cloudwatch_logs.rb
@@ -41,7 +41,7 @@ module Fluent::Plugin
     config_param :remove_log_group_aws_tags_key, :bool, default: false
     config_param :retention_in_days, :integer, default: nil
     config_param :retention_in_days_key, :string, default: nil
-    config_param :remove_retention_in_days, :bool, default: false
+    config_param :remove_retention_in_days_key, :bool, default: false
     config_param :json_handler, :enum, list: [:yajl, :json], :default => :yajl
     config_param :log_rejected_request, :bool, :default => false
 


### PR DESCRIPTION
I found a typo in `remove_retention_in_days` description.

I think `retention_in_days_key` is correct, not `retention_in_days`.
see: https://github.com/fluent-plugins-nursery/fluent-plugin-cloudwatch-logs/blob/51eccdb2a6f22951e542bcef22ebbd769bdcf663/lib/fluent/plugin/out_cloudwatch_logs.rb#L192