### PR TITLE
Enable AWS client logger

### DIFF
--- a/lib/fluent/plugin/out_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/out_cloudwatch_logs.rb
@@ -84,6 +84,8 @@ module Fluent::Plugin
       super
 
       options = {}
+      options[:logger] = log if log
+      options[:log_level] = ({0 => :trace, 1 => :debug, 2 => :info, 3 => :warn, 4 => :error, 5 => :fatal}[log.level] || :info) if log
       options[:region] = @region if @region
       options[:endpoint] = @endpoint if @endpoint
       options[:instance_profile_credentials_retries] = @aws_instance_profile_credentials_retries if @aws_instance_profile_credentials_retries
@@ -101,6 +103,8 @@ module Fluent::Plugin
       @logs ||= Aws::CloudWatchLogs::Client.new(options)
       @sequence_tokens = {}
       @store_next_sequence_token_mutex = Mutex.new
+
+      log.debug "Aws::CloudWatchLogs::Client initialized: log.level #{log.level} => #{options[:log_level]}"
 
       @json_handler = case @json_handler
                       when :yajl


### PR DESCRIPTION
Enable the AWS client's log output using the same `:log_level` as the plugin's `log.level`.

https://docs.aws.amazon.com/sdkforruby/api/Aws/CloudWatch/Client.html
