### PR TITLE
Set up AWS SDK log level to debug

### DIFF
--- a/lib/fluent/plugin/out_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/out_cloudwatch_logs.rb
@@ -85,7 +85,7 @@ module Fluent::Plugin
 
       options = {}
       options[:logger] = log if log
-      options[:log_level] = ({0 => :trace, 1 => :debug, 2 => :info, 3 => :warn, 4 => :error, 5 => :fatal}[log.level] || :info) if log
+      options[:log_level] = :debug if log
       options[:region] = @region if @region
       options[:endpoint] = @endpoint if @endpoint
       options[:instance_profile_credentials_retries] = @aws_instance_profile_credentials_retries if @aws_instance_profile_credentials_retries


### PR DESCRIPTION
Because AWS SDK logger mechanism does not consider log_level but
it always uses specified log_level.

See: https://github.com/aws/aws-sdk-ruby/blob/97b28ccf18558fc908fd56f52741cf3329de9869/gems/aws-sdk-core/lib/aws-sdk-core/plugins/logging.rb#L50-L52

Fixes #175

Signed-off-by: Hiroshi Hatake <hatake@clear-code.com>