### PR TITLE
Check log_groups existence and find log_stream with pagenation

### DIFF
--- a/lib/fluent/plugin/out_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/out_cloudwatch_logs.rb
@@ -488,19 +488,15 @@ module Fluent::Plugin
     end
 
     def find_log_stream(group_name, stream_name)
-      next_token = nil
-      loop do
-        response = @logs.describe_log_streams(log_group_name: group_name, log_stream_name_prefix: stream_name, next_token: next_token)
-        if (log_stream = response.log_streams.find {|i| i.log_stream_name == stream_name })
+      response = @logs.describe_log_streams(log_group_name: group_name, log_stream_name_prefix: stream_name)
+      response.each {|page|
+        if (log_stream = page.log_streams.find {|i| i.log_stream_name == stream_name })
           return log_stream
         end
-        if response.next_token.nil?
-          break
-        end
-        next_token = response.next_token
         sleep 0.1
-      end
-      nil
+      }
     end
+
+    nil
   end
 end

--- a/lib/fluent/plugin/out_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/out_cloudwatch_logs.rb
@@ -455,12 +455,23 @@ module Fluent::Plugin
     def log_group_exists?(group_name)
       if @sequence_tokens[group_name]
         true
-      elsif @logs.describe_log_groups.any? {|page| page.log_groups.any? {|i| i.log_group_name == group_name } }
+      elsif check_log_group_existence(group_name)
         @sequence_tokens[group_name] = {}
         true
       else
         false
       end
+    end
+
+    def check_log_group_existence(group_name)
+      response = @logs.describe_log_groups(log_group_name_prefix: group_name)
+      response.each {|page|
+        if page.log_groups.find {|i| i.log_group_name == group_name }
+          return true
+        end
+      }
+
+      false
     end
 
     def log_stream_exists?(group_name, stream_name)


### PR DESCRIPTION
This should be needed because default response contains only 50
log_group names.

Closes #45 
Fixes #48 

Related to #49

Signed-off-by: Hiroshi Hatake <hatake@clear-code.com>