### PR TITLE
Cloudwatch rate limit retry

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ Please refer to [the PutRetentionPolicy column in documentation](https://docs.aw
 * `log_group_name`: name of log group to fetch logs
 * `log_stream_name`: name of log stream to fetch logs
 * `region`: AWS Region.  See [Authentication](#authentication) for more information.
+* `throttling_retry_seconds`: time period in seconds to retry a request when aws CloudWatch rate limit exceeds (default: nil)
 * `state_file`: file to store current state (e.g. next\_forward\_token)
 * `tag`: fluentd tag
 * `use_log_stream_name_prefix`: to use `log_stream_name` as log stream name prefix (default false)

--- a/test/plugin/test_in_cloudwatch_logs.rb
+++ b/test/plugin/test_in_cloudwatch_logs.rb
@@ -622,7 +622,6 @@ class CloudwatchLogsInputTest < Test::Unit::TestCase
         throttling_retry_seconds 1
       CONFIG
 
-
       # it will raises the error 2 times
       counter = 0
       times = 2

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -42,10 +42,7 @@ module CloudwatchLogsTestHelper
   end
 
   def log_stream_name(log_stream_name_prefix = nil)
-    if !@log_stream_name
-      new_log_stream(log_stream_name_prefix)
-    end
-    @log_stream_name
+    @log_stream_name ||= new_log_stream(log_stream_name_prefix)
   end
 
   def new_log_stream(log_stream_name_prefix = nil)


### PR DESCRIPTION
This pull requests intends to add an option for `in_cloudwatch_logs` in order to retry request when AWS CloudWatch rate limits exceeds.

I'm facing the same problem described [here #114](https://github.com/fluent-plugins-nursery/fluent-plugin-cloudwatch-logs/issues/114) and with the idea from [here](https://github.com/fluent-plugins-nursery/fluent-plugin-cloudwatch-logs/pull/113), this PR came out.

But instead of retrying right after the rate limit error, I think it is suitable wait few seconds.

Im running this version and it is working properly so far.
