### PR TITLE
out_cloudwatch_logs: Use sequence token in exception

### DIFF
--- a/lib/fluent/plugin/out_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/out_cloudwatch_logs.rb
@@ -377,8 +377,7 @@ module Fluent::Plugin
           end
         rescue Aws::CloudWatchLogs::Errors::InvalidSequenceTokenException, Aws::CloudWatchLogs::Errors::DataAlreadyAcceptedException => err
           sleep 1 # to avoid too many API calls
-          log_stream = find_log_stream(group_name, stream_name)
-          store_next_sequence_token(group_name, stream_name, log_stream.upload_sequence_token)
+          store_next_sequence_token(group_name, stream_name, err.expected_sequence_token)
           log.warn "updating upload sequence token forcefully because unrecoverable error occured", {
             "error" => err,
             "log_group" => group_name,


### PR DESCRIPTION
This should be reducing DescribeLogStreams API call.

Fixes #192.

Signed-off-by: Hiroshi Hatake <hatake@clear-code.com>