### PR TITLE
Use storage instead of state file

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,9 @@ Please refer to [the PutRetentionPolicy column in documentation](https://docs.aw
   #<parse>
   # @type none # or csv, tsv, regexp etc.
   #</parse>
+  #<storage>
+  # @type local # or redis, memcached, etc.
+  #</storage>
 </source>
 ```
 
@@ -195,7 +198,7 @@ Please refer to [the PutRetentionPolicy column in documentation](https://docs.aw
 * `region`: AWS Region.  See [Authentication](#authentication) for more information.
 * `throttling_retry_seconds`: time period in seconds to retry a request when aws CloudWatch rate limit exceeds (default: nil)
 * `include_metadata`: include metadata such as `log_group_name` and `log_stream_name`. (default: false)
-* `state_file`: file to store current state (e.g. next\_forward\_token)
+* `state_file`: file to store current state (e.g. next\_forward\_token). This parameter is deprecated. Use `<storage>` instead.
 * `tag`: fluentd tag
 * `use_log_stream_name_prefix`: to use `log_stream_name` as log stream name prefix (default false)
 * `use_todays_log_stream`: use todays and yesterdays date as log stream name prefix (formatted YYYY/MM/DD). (default: `false`)
@@ -205,6 +208,7 @@ Please refer to [the PutRetentionPolicy column in documentation](https://docs.aw
 * `time_range_format`: specify time format for time range. (default: `%Y-%m-%d %H:%M:%S`)
 * `format`: specify CloudWatchLogs' log format. (default `nil`)
 * `<parse>`: specify parser plugin configuration. see also: https://docs.fluentd.org/v/1.0/parser#how-to-use
+* `<storage>`: specify storage plugin configuration. see also: https://docs.fluentd.org/v/1.0/storage#how-to-use
 
 ## Test
 

--- a/test/plugin/test_in_cloudwatch_logs.rb
+++ b/test/plugin/test_in_cloudwatch_logs.rb
@@ -201,7 +201,6 @@ class CloudwatchLogsInputTest < Test::Unit::TestCase
                            '@type' => 'cloudwatch_logs',
                            'log_group_name' => "#{log_group_name}",
                            'log_stream_name' => "#{log_stream_name}",
-                           'state_file' => '/tmp/state',
                           }
       cloudwatch_config = cloudwatch_config.merge!(config_elementify(aws_key_id)) if ENV['aws_key_id']
       cloudwatch_config = cloudwatch_config.merge!(config_elementify(aws_sec_key)) if ENV['aws_sec_key']
@@ -211,7 +210,9 @@ class CloudwatchLogsInputTest < Test::Unit::TestCase
       csv_format_config = config_element('ROOT', '', cloudwatch_config, [
                                            config_element('parse', '', {'@type' => 'csv',
                                                                         'keys' => 'time,message',
-                                                                        'time_key' => 'time'})
+                                                                        'time_key' => 'time'}),
+                                           config_element('storage', '', {'@type' => 'local',
+                                                                          'path' => '/tmp/state'})
                                          ])
       create_log_stream
 
@@ -238,7 +239,6 @@ class CloudwatchLogsInputTest < Test::Unit::TestCase
                            '@type' => 'cloudwatch_logs',
                            'log_group_name' => "#{log_group_name}",
                            'log_stream_name' => "#{log_stream_name}",
-                           'state_file' => '/tmp/state',
                            'include_metadata' => true,
                           }
       cloudwatch_config = cloudwatch_config.merge!(config_elementify(aws_key_id)) if ENV['aws_key_id']
@@ -249,7 +249,10 @@ class CloudwatchLogsInputTest < Test::Unit::TestCase
       csv_format_config = config_element('ROOT', '', cloudwatch_config, [
                                            config_element('parse', '', {'@type' => 'csv',
                                                                         'keys' => 'time,message',
-                                                                        'time_key' => 'time'})
+                                                                        'time_key' => 'time'}),
+                                           config_element('storage', '', {'@type' => 'local',
+                                                                          'path' => '/tmp/state'})
+
                                          ])
       create_log_stream
 
@@ -320,7 +323,6 @@ class CloudwatchLogsInputTest < Test::Unit::TestCase
                            '@type' => 'cloudwatch_logs',
                            'log_group_name' => "#{log_group_name}",
                            'log_stream_name' => "#{log_stream_name}",
-                           'state_file' => '/tmp/state',
                           }
       cloudwatch_config = cloudwatch_config.merge!(config_elementify(aws_key_id)) if ENV['aws_key_id']
       cloudwatch_config = cloudwatch_config.merge!(config_elementify(aws_sec_key)) if ENV['aws_sec_key']
@@ -330,7 +332,9 @@ class CloudwatchLogsInputTest < Test::Unit::TestCase
       regex_format_config = config_element('ROOT', '', cloudwatch_config, [
                                            config_element('parse', '', {'@type' => 'regexp',
                                                                         'expression' => "/^(?<cloudwatch>[^ ]*)?/",
-                                                                       })
+                                                                       }),
+                                           config_element('storage', '', {'@type' => 'local',
+                                                                          'path' => '/tmp/state'})
                                          ])
       create_log_stream
 


### PR DESCRIPTION
Using storage plugin helper, users can store token state with arbitrary store plugin such as local, redis, memcached etc.