### PR TITLE
Fix typos in STS endpoint setup

### DIFF
--- a/lib/fluent/plugin/in_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/in_cloudwatch_logs.rb
@@ -89,9 +89,9 @@ module Fluent::Plugin
         }
         credentials_options[:sts_endpoint_url] = @aws_sts_endpoint_url if @aws_sts_endpoint_url
         if @region and @aws_sts_endpoint_url
-          credentails_options[:client] = Aws::STS::Client.new(:region => @region, endpoint: @aws_sts_endpoint_url)
+          credentials_options[:client] = Aws::STS::Client.new(:region => @region, endpoint: @aws_sts_endpoint_url)
         elsif @region
-          credentails_options[:client] = Aws::STS::Client.new(:region => @region)
+          credentials_options[:client] = Aws::STS::Client.new(:region => @region)
         end
         options[:credentials] = Aws::AssumeRoleCredentials.new(credentials_options)
       elsif @web_identity_credentials

--- a/lib/fluent/plugin/out_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/out_cloudwatch_logs.rb
@@ -108,9 +108,9 @@ module Fluent::Plugin
         }
         credentials_options[:sts_endpoint_url] = @aws_sts_endpoint_url if @aws_sts_endpoint_url
         if @region and @aws_sts_endpoint_url
-          credentails_options[:client] = Aws::STS::Client.new(:region => @region, endpoint: @aws_sts_endpoint_url)
+          credentials_options[:client] = Aws::STS::Client.new(:region => @region, endpoint: @aws_sts_endpoint_url)
         elsif @region
-          credentails_options[:client] = Aws::STS::Client.new(:region => @region)
+          credentials_options[:client] = Aws::STS::Client.new(:region => @region)
         end
         options[:credentials] = Aws::AssumeRoleCredentials.new(credentials_options)
       elsif @web_identity_credentials


### PR DESCRIPTION
Apparent typo in STS endpoint setup code, as evident by errors when used with Fluentd to query CloudWatch Logs:

```
unexpected error error_class=NameError error=\"undefined local variable or method `credentails_options' for #<Fluent::Plugin::CloudwatchLogsInput:0...>\"
```