### PR TITLE
attempt to fix issue with token not being read

### DIFF
--- a/lib/fluent/plugin/in_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/in_cloudwatch_logs.rb
@@ -266,7 +266,11 @@ module Fluent::Plugin
         }
         request.merge!(start_time: @start_time) if @start_time
         request.merge!(end_time: @end_time) if @end_time
-        log_next_token = next_token(log_group_name, log_stream_name)
+        if @use_log_group_name_prefix
+          log_next_token = next_token(log_stream_name, log_group_name)
+        else
+          log_next_token = next_token(log_stream_name)
+        end
         request[:next_token] = log_next_token if !log_next_token.nil? && !log_next_token.empty?
         response = @logs.get_log_events(request)
         if valid_next_token(log_next_token, response.next_forward_token)


### PR DESCRIPTION
A recent change introduced a regressions - The cloudwatch log groups are re-read due to issues with token handling. It seems the cloud watch token read != write  most likely introduced in #215.

This is by no means a mergeable PR - my ruby skills are non-existant.

config:
```
<source>
  @id cloudwatch_logs_cloudhsm
  @type cloudwatch_logs
  log_group_name /aws/cloudhsm/<reducted>
  log_stream_name hsm
  use_log_stream_name_prefix true

  region "#{ENV['AWS_REGION']}"

  <storage>
    @type local
    persistent true
  </storage>

  <parse>
    @type none
    message_key log
  </parse>
  tag cloudwatch_logs.cloudhsm
  include_metadata true
</source>
```
Thank you all for supporting and maintaining this great plugin :)