### PR TITLE
add aws_sts_external_id as config param

### DIFF
--- a/lib/fluent/plugin/in_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/in_cloudwatch_logs.rb
@@ -16,6 +16,7 @@ module Fluent::Plugin
     config_param :aws_sec_key, :string, default: nil, secret: true
     config_param :aws_use_sts, :bool, default: false
     config_param :aws_sts_role_arn, :string, default: nil
+    config_param :aws_sts_external_id, :string, default: nil
     config_param :aws_sts_session_name, :string, default: 'fluentd'
     config_param :aws_sts_endpoint_url, :string, default: nil
     config_param :region, :string, default: nil
@@ -88,7 +89,8 @@ module Fluent::Plugin
         Aws.config[:region] = options[:region]
         credentials_options = {
           role_arn: @aws_sts_role_arn,
-          role_session_name: @aws_sts_session_name
+          role_session_name: @aws_sts_session_name,
+          external_id: @aws_sts_external_id
         }
         credentials_options[:sts_endpoint_url] = @aws_sts_endpoint_url if @aws_sts_endpoint_url
         if @region and @aws_sts_endpoint_url

--- a/lib/fluent/plugin/in_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/in_cloudwatch_logs.rb
@@ -93,7 +93,7 @@ module Fluent::Plugin
           role_arn: @aws_sts_role_arn,
           role_session_name: @aws_sts_session_name,
           external_id: @aws_sts_external_id,
-          policy: @aws_sts_policy
+          policy: @aws_sts_policy,
           duration_seconds: @aws_sts_duration_seconds
         }
         credentials_options[:sts_endpoint_url] = @aws_sts_endpoint_url if @aws_sts_endpoint_url

--- a/lib/fluent/plugin/in_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/in_cloudwatch_logs.rb
@@ -16,8 +16,10 @@ module Fluent::Plugin
     config_param :aws_sec_key, :string, default: nil, secret: true
     config_param :aws_use_sts, :bool, default: false
     config_param :aws_sts_role_arn, :string, default: nil
-    config_param :aws_sts_external_id, :string, default: nil
     config_param :aws_sts_session_name, :string, default: 'fluentd'
+    config_param :aws_sts_external_id, :string, default: nil
+    config_param :aws_sts_policy, :string, default: nil
+    config_param :aws_sts_duration_seconds, :time, default: nil
     config_param :aws_sts_endpoint_url, :string, default: nil
     config_param :region, :string, default: nil
     config_param :endpoint, :string, default: nil
@@ -90,7 +92,9 @@ module Fluent::Plugin
         credentials_options = {
           role_arn: @aws_sts_role_arn,
           role_session_name: @aws_sts_session_name,
-          external_id: @aws_sts_external_id
+          external_id: @aws_sts_external_id,
+          policy: @aws_sts_policy
+          duration_seconds: @aws_sts_duration_seconds
         }
         credentials_options[:sts_endpoint_url] = @aws_sts_endpoint_url if @aws_sts_endpoint_url
         if @region and @aws_sts_endpoint_url

--- a/lib/fluent/plugin/out_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/out_cloudwatch_logs.rb
@@ -18,8 +18,10 @@ module Fluent::Plugin
     config_param :aws_instance_profile_credentials_retries, :integer, default: nil
     config_param :aws_use_sts, :bool, default: false
     config_param :aws_sts_role_arn, :string, default: nil
-    config_param :aws_sts_external_id, :string, default: nil
     config_param :aws_sts_session_name, :string, default: 'fluentd'
+    config_param :aws_sts_external_id, :string, default: nil
+    config_param :aws_sts_policy, :string, default: nil
+    config_param :aws_sts_duration_seconds, :time, default: nil
     config_param :aws_sts_endpoint_url, :string, default: nil
     config_param :region, :string, :default => nil
     config_param :endpoint, :string, :default => nil
@@ -126,6 +128,8 @@ module Fluent::Plugin
           role_arn: @aws_sts_role_arn,
           role_session_name: @aws_sts_session_name,
           external_id: @aws_sts_external_id
+          policy: @aws_sts_policy
+          duration_seconds: @aws_sts_duration_seconds
         }
         credentials_options[:sts_endpoint_url] = @aws_sts_endpoint_url if @aws_sts_endpoint_url
         if @region and @aws_sts_endpoint_url

--- a/lib/fluent/plugin/out_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/out_cloudwatch_logs.rb
@@ -127,8 +127,8 @@ module Fluent::Plugin
         credentials_options = {
           role_arn: @aws_sts_role_arn,
           role_session_name: @aws_sts_session_name,
-          external_id: @aws_sts_external_id
-          policy: @aws_sts_policy
+          external_id: @aws_sts_external_id,
+          policy: @aws_sts_policy,
           duration_seconds: @aws_sts_duration_seconds
         }
         credentials_options[:sts_endpoint_url] = @aws_sts_endpoint_url if @aws_sts_endpoint_url

--- a/lib/fluent/plugin/out_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/out_cloudwatch_logs.rb
@@ -18,6 +18,7 @@ module Fluent::Plugin
     config_param :aws_instance_profile_credentials_retries, :integer, default: nil
     config_param :aws_use_sts, :bool, default: false
     config_param :aws_sts_role_arn, :string, default: nil
+    config_param :aws_sts_external_id, :string, default: nil
     config_param :aws_sts_session_name, :string, default: 'fluentd'
     config_param :aws_sts_endpoint_url, :string, default: nil
     config_param :region, :string, :default => nil
@@ -123,7 +124,8 @@ module Fluent::Plugin
         Aws.config[:region] = options[:region]
         credentials_options = {
           role_arn: @aws_sts_role_arn,
-          role_session_name: @aws_sts_session_name
+          role_session_name: @aws_sts_session_name,
+          external_id: @aws_sts_external_id
         }
         credentials_options[:sts_endpoint_url] = @aws_sts_endpoint_url if @aws_sts_endpoint_url
         if @region and @aws_sts_endpoint_url


### PR DESCRIPTION
Enhancement to include `aws_sts_external_id` and other optional params (`aws_sts_policy`, `aws_sts_duration_seconds`) as config parameter to support cross account access. 

s3 [plugin](https://github.com/fluent/fluent-plugin-s3/blob/master/docs/credentials.md) for fluentd also supports external_id and optional params for assume role credentials.

fixes https://github.com/fluent-plugins-nursery/fluent-plugin-cloudwatch-logs/issues/232