### PR TITLE
Add start-from-head when starttime, endtime, or next_token are present

### DIFF
--- a/lib/fluent/plugin/in_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/in_cloudwatch_logs.rb
@@ -272,6 +272,7 @@ module Fluent::Plugin
           log_next_token = next_token(log_stream_name)
         end
         request[:next_token] = log_next_token if !log_next_token.nil? && !log_next_token.empty?
+        request[:start_from_head] = true if (!log_next_token.nil? && !log_next_token.empty?) || @start_time || @end_time
         response = @logs.get_log_events(request)
         if valid_next_token(log_next_token, response.next_forward_token)
           if @use_log_group_name_prefix

--- a/lib/fluent/plugin/in_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/in_cloudwatch_logs.rb
@@ -272,7 +272,7 @@ module Fluent::Plugin
           log_next_token = next_token(log_stream_name)
         end
         request[:next_token] = log_next_token if !log_next_token.nil? && !log_next_token.empty?
-        request[:start_from_head] = true if (!log_next_token.nil? && !log_next_token.empty?) || @start_time || @end_time
+        request[:start_from_head] = true if read_from_head?(log_next_token)
         response = @logs.get_log_events(request)
         if valid_next_token(log_next_token, response.next_forward_token)
           if @use_log_group_name_prefix
@@ -284,6 +284,10 @@ module Fluent::Plugin
 
         response.events
       end
+    end
+
+    def read_from_head?(next_token)
+      (!next_token.nil? && !next_token.empty?) || @start_time || @end_time
     end
 
     def describe_log_streams(log_stream_name_prefix, log_streams = nil, next_token = nil, log_group_name=nil)


### PR DESCRIPTION
The fix we're using for #234 , based on notes from https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_GetLogEvents.html#API_GetLogEvents_RequestSyntax , 

```
 startFromHead
    If the value is true, the earliest log events are returned first. If the value is false, the latest log events are returned first. The default value is false.
    If you are using nextToken in this operation, you must specify true for startFromHead.
    Type: Boolean
    Required: No
```