### PR TITLE
Added support for passing the ssl_verify_peer flag to the AWS SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ export AWS_ACCESS_KEY_ID="YOUR_ACCESS_KEY"
 export AWS_SECRET_ACCESS_KEY="YOUR_SECRET_ACCESS_KEY"
 ```
 
-Note: For this to work persistently the enviornment will need to be set in the startup scripts or docker variables.
+Note: For this to work persistently the environment will need to be set in the startup scripts or docker variables.
 
 ### AWS Configuration
 
@@ -184,6 +184,7 @@ Fetch sample log from CloudWatch Logs:
 * `aws_sec_key`: AWS Secret Access Key.  See [Authentication](#authentication) for more information.
 * `concurrency`: use to set the number of threads pushing data to CloudWatch. (default: 1)
 * `endpoint`: use this parameter to connect to the local API endpoint (for testing)
+* `ssl_verify_peer`: when `true` (default), SSL peer certificates are verified when establishing a connection. Setting to `false` can be useful for testing.
 * `http_proxy`: use to set an optional HTTP proxy
 * `include_time_key`: include time key as part of the log entry (defaults to UTC)
 * `json_handler`: name of the library to be used to handle JSON data. For now, supported libraries are `json` (default) and `yajl`.
@@ -263,6 +264,7 @@ Please refer to [the PutRetentionPolicy column in documentation](https://docs.aw
 * `aws_sts_session_name`: the session name to use with sts authentication (default: `fluentd`)
 * `aws_use_sts`: use [AssumeRoleCredentials](http://docs.aws.amazon.com/sdkforruby/api/Aws/AssumeRoleCredentials.html) to authenticate, rather than the [default credential hierarchy](http://docs.aws.amazon.com/sdkforruby/api/Aws/CloudWatchLogs/Client.html#initialize-instance_method). See 'Cross-Account Operation' below for more detail.
 * `endpoint`: use this parameter to connect to the local API endpoint (for testing)
+* `ssl_verify_peer`: when `true` (default), SSL peer certificates are verified when establishing a connection. Setting to `false` can be useful for testing.
 * `fetch_interval`: time period in seconds between checking CloudWatch for new logs. (default: 60)
 * `http_proxy`: use to set an optional HTTP proxy
 * `json_handler`:  name of the library to be used to handle JSON data. For now, supported libraries are `json` (default) and `yajl`.

--- a/lib/fluent/plugin/in_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/in_cloudwatch_logs.rb
@@ -23,6 +23,7 @@ module Fluent::Plugin
     config_param :aws_sts_endpoint_url, :string, default: nil
     config_param :region, :string, default: nil
     config_param :endpoint, :string, default: nil
+    config_param :ssl_verify_peer, :bool, :default => true
     config_param :tag, :string
     config_param :log_group_name, :string
     config_param :add_log_group_name, :bool, default: false
@@ -85,6 +86,7 @@ module Fluent::Plugin
       options = {}
       options[:region] = @region if @region
       options[:endpoint] = @endpoint if @endpoint
+      options[:ssl_verify_peer] = @ssl_verify_peer
       options[:http_proxy] = @http_proxy if @http_proxy
 
       if @aws_use_sts

--- a/lib/fluent/plugin/out_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/out_cloudwatch_logs.rb
@@ -25,6 +25,7 @@ module Fluent::Plugin
     config_param :aws_sts_endpoint_url, :string, default: nil
     config_param :region, :string, :default => nil
     config_param :endpoint, :string, :default => nil
+    config_param :ssl_verify_peer, :bool, :default => true
     config_param :log_group_name, :string, :default => nil
     config_param :log_stream_name, :string, :default => nil
     config_param :auto_create_stream, :bool, default: false
@@ -120,6 +121,7 @@ module Fluent::Plugin
       options[:log_level] = :debug if log
       options[:region] = @region if @region
       options[:endpoint] = @endpoint if @endpoint
+      options[:ssl_verify_peer] = @ssl_verify_peer
       options[:instance_profile_credentials_retries] = @aws_instance_profile_credentials_retries if @aws_instance_profile_credentials_retries
 
       if @aws_use_sts


### PR DESCRIPTION
This is useful for testing against the https://github.com/spulec/moto AWS mock server, which by default runs with a self-signed certificate.