### PR TITLE
in_cloudwatch_logs: fix error while fetching yesterdays logstream with prefix

### DIFF
--- a/lib/fluent/plugin/in_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/in_cloudwatch_logs.rb
@@ -199,7 +199,7 @@ module Fluent::Plugin
               log_stream_name_prefix = @use_todays_log_stream ? get_todays_date : @log_stream_name
               begin
                 log_streams = describe_log_streams(log_stream_name_prefix, nil, nil, log_group_name)
-                log_streams.concat(describe_log_streams(get_yesterdays_date)) if @use_todays_log_stream
+                log_streams.concat(describe_log_streams(get_yesterdays_date, nil, nil, log_group_name)) if @use_todays_log_stream
                 log_streams.each do |log_stream|
                   log_stream_name = log_stream.log_stream_name
                   events = get_events(log_group_name, log_stream_name)


### PR DESCRIPTION
Using `in_cloudwatch` with below settings:
```
<source>
  @type cloudwatch_logs
  region us-east-1
  aws_use_sts true
  aws_sts_role_arn <redacted>
  log_group_name /aws/lambda/prod
  use_log_group_name_prefix true
  include_metadata true
  use_todays_log_stream true
  format /(?<message>.+)/
  tag cloudwatch.input
  <storage>
   @type local
   path /var/tmp/cloudwatchstate
  </storage>
</source>
```

This gives below error while describing yesterday's log streams.

```
2021-11-16 14:05:26 +0000 [warn]: #0 fluent/log.rb:351:warn: '' prefixed log stream(s) are not found
2021-11-16 14:05:27 +0000 [warn]: #0 fluent/log.rb:351:warn: '' prefixed log stream(s) are not found
2021-11-16 14:05:27 +0000 [warn]: #0 fluent/log.rb:351:warn: '' prefixed log stream(s) are not found
2021-11-16 14:05:27 +0000 [warn]: #0 fluent/log.rb:351:warn: '' prefixed log stream(s) are not found
```

This PR fixes the issue by passing the log group name while fetching log streams with yesterday's prefix.
