### PR TITLE
Increase max event size to 1MB

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ rake test
 
 ## Caution
 
-If an event message exceeds API limit (256KB), the event will be discarded.
+If an event message exceeds API limit (1MB), the event will be discarded.
 
 ## Cross-Account Operation
 

--- a/lib/fluent/plugin/out_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/out_cloudwatch_logs.rb
@@ -68,7 +68,7 @@ module Fluent::Plugin
     end
 
     MAX_EVENTS_SIZE = 1_048_576
-    MAX_EVENT_SIZE = 256 * 1024
+    MAX_EVENT_SIZE = 1024 * 1024
     EVENT_HEADER_SIZE = 26
 
     def initialize

--- a/test/plugin/test_out_cloudwatch_logs.rb
+++ b/test/plugin/test_out_cloudwatch_logs.rb
@@ -974,11 +974,11 @@ class CloudwatchLogsOutputTest < Test::Unit::TestCase
         @log_level debug
       EOC
       d.run(default_tag: fluentd_tag) do
-        d.feed(time, {'message' => '*' * 256 * 1024})
+        d.feed(time, {'message' => '*' * 1024 * 1024})
       end
 
       logs = d.logs
-      assert(logs.any?{|log| log =~ /Log event in .* discarded because it is too large: 262184 bytes exceeds limit of 262144/})
+      assert(logs.any?{|log| log =~ /Log event in .* discarded because it is too large/})
     end
 
     def test_do_not_emit_empty_record


### PR DESCRIPTION
AWS has increased the max event size to 1 MB: [AWS News](https://aws.amazon.com/about-aws/whats-new/2025/04/amazon-cloudwatch-logs-increases-log-event-size-1-mb/#:~:text=Amazon%20CloudWatch%20Logs%20now%20supports,visit%20the%20CloudWatch%20Logs%20documentation.)

This is already reflected in the code in some places: [Line 376](https://github.com/fluent-plugins-nursery/fluent-plugin-cloudwatch-logs/blob/7287d1ae78b24e3fb74aee8d3830a65ecd89f65d/lib/fluent/plugin/out_cloudwatch_logs.rb#L376) and [Line 70](https://github.com/fluent-plugins-nursery/fluent-plugin-cloudwatch-logs/blob/7287d1ae78b24e3fb74aee8d3830a65ecd89f65d/lib/fluent/plugin/out_cloudwatch_logs.rb#L70)

However, the variable MAX_EVENT_SIZE has not been updated. As such, we are still seeing errors reporting that the log event is too large. 