### PR TITLE
ci: Remove unnecessary gem install to fix CI error

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -21,6 +21,5 @@ jobs:
       env:
         CI: true
       run: |
-        gem install bundler rake
         bundle install --jobs 4 --retry 3
         bundle exec rake test

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -21,6 +21,5 @@ jobs:
       env:
         CI: true
       run: |
-        gem install bundler rake
         bundle install --jobs 4 --retry 3
         bundle exec rake test


### PR DESCRIPTION
`bundler` gem will be installed automatically by `setup-ruby` action.

This PR will fix CI error in https://github.com/fluent-plugins-nursery/fluent-plugin-cloudwatch-logs/actions/runs/14924776507