### PR TITLE
ci: fix branch name

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -2,7 +2,7 @@ name: Testing on Ubuntu
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
 jobs:
   build:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -2,7 +2,7 @@ name: Testing on Windows
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
 jobs:
   build:


### PR DESCRIPTION
We have used `master` branch in this plugin.
https://github.com/fluent-plugins-nursery/fluent-plugin-cloudwatch-logs/branches

This PR will fix branch name in https://github.com/fluent-plugins-nursery/fluent-plugin-cloudwatch-logs/pull/269