### PR TITLE
Replace yajl-ruby with the json gem for JSON handling

### DIFF
--- a/lib/fluent/plugin/in_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/in_cloudwatch_logs.rb
@@ -2,7 +2,6 @@ require 'date'
 require 'time'
 require 'fluent/plugin/input'
 require 'fluent/plugin/parser'
-require 'yajl'
 
 module Fluent::Plugin
   class CloudwatchLogsInput < Input
@@ -36,7 +35,7 @@ module Fluent::Plugin
                  deprecated: "Use <storage> instead."
     config_param :fetch_interval, :time, default: 60
     config_param :http_proxy, :string, default: nil
-    config_param :json_handler, :enum, list: [:yajl, :json], default: :yajl
+    config_param :json_handler, :enum, list: [:yajl, :json], default: :json # NOTE: Contains yajl for backward compatibility
     config_param :use_todays_log_stream, :bool, default: false
     config_param :use_aws_timestamp, :bool, default: false
     config_param :start_time, :string, default: nil
@@ -132,9 +131,7 @@ module Fluent::Plugin
       thread_create(:in_cloudwatch_logs_runner, &method(:run))
 
       @json_handler = case @json_handler
-                      when :yajl
-                        Yajl
-                      when :json
+                      when :yajl, :json
                         JSON
                       end
     end
@@ -264,7 +261,7 @@ module Fluent::Plugin
             record.merge!("metadata" => metadata)
           end
           router.emit(@tag, time, record)
-        rescue JSON::ParserError, Yajl::ParseError => error # Catch parser errors
+        rescue JSON::ParserError => error # Catch parser errors
           log.error "Invalid JSON encountered while parsing event.message"
           router.emit_error_event(@tag, time, { message: event.message }, error)
         end

--- a/lib/fluent/plugin/in_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/in_cloudwatch_logs.rb
@@ -131,7 +131,10 @@ module Fluent::Plugin
       thread_create(:in_cloudwatch_logs_runner, &method(:run))
 
       @json_handler = case @json_handler
-                      when :yajl, :json
+                      when :yajl
+                        log.info "json_handler 'yajl' is deprecated. Please use 'json' instead."
+                        JSON
+                      when :json
                         JSON
                       end
     end

--- a/lib/fluent/plugin/out_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/out_cloudwatch_logs.rb
@@ -1,7 +1,6 @@
 require 'fluent/plugin/output'
 require 'fluent/msgpack_factory'
 require 'thread'
-require 'yajl'
 
 module Fluent::Plugin
   class CloudwatchLogsOutput < Output
@@ -50,7 +49,7 @@ module Fluent::Plugin
     config_param :retention_in_days, :integer, default: nil
     config_param :retention_in_days_key, :string, default: nil
     config_param :remove_retention_in_days_key, :bool, default: false
-    config_param :json_handler, :enum, list: [:yajl, :json], :default => :yajl
+    config_param :json_handler, :enum, list: [:yajl, :json], :default => :json
     config_param :log_rejected_request, :bool, :default => false
     config_section :web_identity_credentials, multi: false do
       config_param :role_arn, :string
@@ -168,9 +167,7 @@ module Fluent::Plugin
       log.debug "Aws::CloudWatchLogs::Client initialized: log.level #{log.level} => #{options[:log_level]}"
 
       @json_handler = case @json_handler
-                      when :yajl
-                        Yajl
-                      when :json
+                      when :yajl, :json
                         JSON
                       end
     end

--- a/lib/fluent/plugin/out_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/out_cloudwatch_logs.rb
@@ -167,7 +167,10 @@ module Fluent::Plugin
       log.debug "Aws::CloudWatchLogs::Client initialized: log.level #{log.level} => #{options[:log_level]}"
 
       @json_handler = case @json_handler
-                      when :yajl, :json
+                      when :yajl
+                        log.info "json_handler 'yajl' is deprecated. Please use 'json' instead."
+                        JSON
+                      when :json
                         JSON
                       end
     end

--- a/test/plugin/test_in_cloudwatch_logs.rb
+++ b/test/plugin/test_in_cloudwatch_logs.rb
@@ -40,7 +40,7 @@ class CloudwatchLogsInputTest < Test::Unit::TestCase
       assert_equal('stream', d.instance.log_stream_name)
       assert_equal(true, d.instance.use_log_stream_name_prefix)
       assert_equal('/tmp/state', d.instance.state_file)
-      assert_equal(:yajl, d.instance.json_handler)
+      assert_equal(:json, d.instance.json_handler)
       assert_equal(true, d.instance.use_aws_timestamp)
       assert_equal(1560816000000, d.instance.start_time)
       assert_equal(1579305600000, d.instance.end_time)

--- a/test/plugin/test_out_cloudwatch_logs.rb
+++ b/test/plugin/test_out_cloudwatch_logs.rb
@@ -37,7 +37,7 @@ class CloudwatchLogsOutputTest < Test::Unit::TestCase
       assert_equal("tagvalue", d.instance.log_group_aws_tags.fetch("tagkey"))
       assert_equal("tagvalue_2", d.instance.log_group_aws_tags.fetch("tagkey_2"))
       assert_equal(5, d.instance.retention_in_days)
-      assert_equal(:yajl, d.instance.json_handler)
+      assert_equal(:json, d.instance.json_handler)
       assert_equal(["fluentd","aws","cloudwatch"], d.instance.message_keys)
     end
   end


### PR DESCRIPTION
Since the yajl-ruby gem depends on a deprecated Ruby C API, it cannot be installed with Ruby 4.1.