### PR TITLE
Allow duplicate keys in JSON parser

### DIFF
--- a/lib/fluent/plugin/in_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/in_cloudwatch_logs.rb
@@ -130,13 +130,11 @@ module Fluent::Plugin
       @finished = false
       thread_create(:in_cloudwatch_logs_runner, &method(:run))
 
-      @json_handler = case @json_handler
-                      when :yajl
-                        log.info "json_handler 'yajl' is deprecated. Please use 'json' instead."
-                        JSON
-                      when :json
-                        JSON
-                      end
+      # Only check for deprecated json_handler
+      case @json_handler
+      when :yajl
+        log.info "json_handler 'yajl' is deprecated. Please use 'json' instead."
+      end
     end
 
     def shutdown
@@ -256,7 +254,7 @@ module Fluent::Plugin
       else
         time = (event.timestamp / 1000).floor
         begin
-          record = @json_handler.load(event.message)
+          record = JSON.parse(event.message, allow_duplicate_key: true)
           if @add_log_group_name
             record[@log_group_name_key] = group
           end

--- a/lib/fluent/plugin/out_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/out_cloudwatch_logs.rb
@@ -104,7 +104,7 @@ module Fluent::Plugin
                             }
                           else
                             Proc.new { |tag, time, record|
-                              @json_handler.dump(record)
+                              JSON.generate(record)
                             }
                           end
                         else
@@ -166,13 +166,11 @@ module Fluent::Plugin
 
       log.debug "Aws::CloudWatchLogs::Client initialized: log.level #{log.level} => #{options[:log_level]}"
 
-      @json_handler = case @json_handler
-                      when :yajl
-                        log.info "json_handler 'yajl' is deprecated. Please use 'json' instead."
-                        JSON
-                      when :json
-                        JSON
-                      end
+      # Only check for deprecated json_handler
+      case @json_handler
+      when :yajl
+        log.info "json_handler 'yajl' is deprecated. Please use 'json' instead."
+      end
     end
 
     def format(tag, time, record)


### PR DESCRIPTION
The json gem emits a deprecation warning for duplicate keys in JSON objects and will raise `JSON::ParserError` in json 3.0 unless `allow_duplicate_key: true` is specified.

The plugin has historically accepted duplicate keys silently (last value wins).
To preserve this behavior uniformly regardless of the json gem version, this passes `allow_duplicate_key: true` to `JSON.parse`.

This also replaces `JSON.load` with `JSON.parse` to pass the option explicitly. As a side effect, `create_additions` is no longer enabled and an empty message now raises `JSON::ParserError` (routed to the error stream) instead of returning nil. Both are safer behaviors for untrusted log data.

Note that `allow_duplicate_key` is silently ignored by json < 2.13, so this is safe with older json gem versions.